### PR TITLE
Fixes ValueType for Reference when attaching the BinaryToken to the signature.

### DIFF
--- a/src/Wse/WSSESoap.php
+++ b/src/Wse/WSSESoap.php
@@ -193,6 +193,7 @@ class WSSESoap {
             $tokenRef = $this->soapDoc->createElementNS(WSSESoap::WSSENS, WSSESoap::WSSEPFX.':SecurityTokenReference'); 
             $keyInfo->appendChild($tokenRef); 
             $reference = $this->soapDoc->createElementNS(WSSESoap::WSSENS, WSSESoap::WSSEPFX.':Reference'); 
+            $reference->setAttribute('ValueType', $token->getAttribute('ValueType'));
             $reference->setAttribute("URI", $tokenURI); 
             $tokenRef->appendChild($reference); 
         } else { 


### PR DESCRIPTION

The following error occurs when the `ValueType` is missing on the `Reference` element in the `SecurityTokenReference` section.

```
BSP:R3058: Any STR_REFERENCE ValueType attribute MUST contain a value for the referenced SECURITY_TOKEN specified by the corresponding security token profile
```

The `<Reference>` element seems to need the `ValueType` from the token as well.